### PR TITLE
Update launch config

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,7 @@ Requirement: Zabbix Server 3.0+
 3. Copy scripts to where you wish;
 4. Add to zabbix_agent.conf how bellow:
 Timeout=5
-UserParameter=hyperv_replica[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\Scripts\hyperv_replica.ps1" $1 $2
+UserParameter=hyperv_replica[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\Scripts\hyperv_replica.ps1" $1 "$2"
 UserParameter=hyperv_replica_discover,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\Scripts\hyperv_replica_discover.ps1"
 
 

--- a/zabbix_agent.conf.txt
+++ b/zabbix_agent.conf.txt
@@ -1,3 +1,3 @@
 Timeout=5
-UserParameter=hyperv_replica[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\Scripts\hyperv_replica.ps1" $1 $2
+UserParameter=hyperv_replica[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\Scripts\hyperv_replica.ps1" $1 "$2"
 UserParameter=hyperv_replica_discover,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Zabbix\Scripts\hyperv_replica_discover.ps1"


### PR DESCRIPTION
HyperV machines can have spaces in the names, if $2 is not quoted this sometimes causes issues with tokenisation through zabbix